### PR TITLE
Fix ram data size issue 

### DIFF
--- a/Eclipse/m32_uart_buffer/Makefile
+++ b/Eclipse/m32_uart_buffer/Makefile
@@ -1,0 +1,101 @@
+MCU = atmega32
+FORMAT = ihex
+TARGET = rbsh
+SRC = main.cpp cmds.cpp uart_interpreter.cpp
+
+CXXFLAGS = -Os -g0 -std=gnu++11 -DF_CPU=16000000 -ffunction-sections -fdata-sections
+
+MATH_LIB = -lm
+
+LDFLAGS = $(EXTMEMOPTS) $(LDMAP) $(PRINTF_LIB) $(SCANF_LIB) $(MATH_LIB) -Wl,--gc-sections -Wl,-Map=$(TARGET).map -T"./atmega32.ld"
+
+CC = avr-gcc
+CXX = avr-g++
+OBJCOPY = avr-objcopy
+OBJDUMP = avr-objdump
+SIZE = avr-size
+NM = avr-nm
+REMOVE = rm -f
+MV = mv -f
+
+# Define all object files.
+OBJ = $(SRC:.cpp=.o)  
+
+# Define all listing files.
+LST = $(SRC:.cpp=.lst)
+
+# Combine all necessary flags and optional flags.
+# Add target processor to flags.
+ALL_CXXFLAGS = -mmcu=$(MCU) -I. $(CXXFLAGS)
+
+# Default target.
+all: build
+
+build: elf hex eep
+	$(SIZE) --format=berkeley --mcu=$(MCU) $(TARGET).elf
+
+elf: $(TARGET).elf
+hex: $(TARGET).hex
+eep: $(TARGET).eep
+lss: $(TARGET).lss 
+sym: $(TARGET).sym
+
+.SUFFIXES: .elf .hex .eep .lss .sym
+
+.elf.hex:
+	$(OBJCOPY) -O $(FORMAT) -R .eeprom $< $@
+
+.elf.eep:
+	-$(OBJCOPY) -j .eeprom --set-section-flags=.eeprom="alloc,load" \
+	--change-section-lma .eeprom=0 -O $(FORMAT) $< $@
+
+# Create extended listing file from ELF output file.
+.elf.lss:
+	$(OBJDUMP) -h -S $< > $@
+
+# Create a symbol table from ELF output file.
+.elf.sym:
+	$(NM) -n $< > $@
+
+
+
+# Link: create ELF output file from object files.
+$(TARGET).elf: $(OBJ)
+	$(CXX) $(ALL_CXXFLAGS) $(OBJ) --output $@ $(LDFLAGS)
+
+
+# Compile: create object files from C source files.
+.cpp.o:
+	$(CXX) -c $(ALL_CXXFLAGS) $< -o $@ 
+
+
+# Compile: create assembler files from C source files.
+.cpp.s:
+	$(CXX) -S $(ALL_CXXFLAGS) $< -o $@
+
+
+# Assemble: create object files from assembler source files.
+.S.o:
+	$(CC) -c $(ALL_ASFLAGS) $< -o $@
+
+
+
+# Target: clean project.
+clean:
+	$(REMOVE) $(TARGET).hex $(TARGET).eep $(TARGET).cof $(TARGET).elf \
+	$(TARGET).map $(TARGET).sym $(TARGET).lss \
+	$(OBJ) $(LST) $(SRC:.cpp=.s) $(SRC:.cpp=.d)
+
+depend:
+	if grep '^# DO NOT DELETE' $(MAKEFILE) >/dev/null; \
+	then \
+		sed -e '/^# DO NOT DELETE/,$$d' $(MAKEFILE) > \
+			$(MAKEFILE).$$$$ && \
+		$(MV) $(MAKEFILE).$$$$ $(MAKEFILE); \
+	fi
+	echo '# DO NOT DELETE THIS LINE -- make depend depends on it.' \
+		>> $(MAKEFILE); \
+	$(CC) -M -mmcu=$(MCU) $(CDEFS) $(CINCS) $(SRC) $(ASRC) >> $(MAKEFILE)
+
+.PHONY: all build elf hex eep lss sym clean depend
+

--- a/Eclipse/m32_uart_buffer/atmega32.ld
+++ b/Eclipse/m32_uart_buffer/atmega32.ld
@@ -1,0 +1,270 @@
+/* Default linker script, for normal executables */
+/* Copyright (C) 2014 Free Software Foundation, Inc.
+   Copying and distribution of this script, with or without modification,
+   are permitted in any medium without royalty provided the copyright
+   notice and this notice are preserved.  */
+OUTPUT_FORMAT("elf32-avr","elf32-avr","elf32-avr")
+OUTPUT_ARCH(avr:5)
+
+MEMORY
+{
+  TEXT              (rx)   : ORIGIN = 0,        LENGTH = 128K
+  DATA              (rw!x) : ORIGIN = 0x800060, LENGTH = 0xffa0
+  EEPROM            (rw!x) : ORIGIN = 0x810000, LENGTH = 64K
+  FUSE              (rw!x) : ORIGIN = 0x820000, LENGTH = 1K
+  LOCK              (rw!x) : ORIGIN = 0x830000, LENGTH = 1K
+  SIGNATURE         (rw!x) : ORIGIN = 0x840000, LENGTH = 1K
+  USER_SIGNATURES   (rw!x) : ORIGIN = 0x850000, LENGTH = 1K
+}
+
+SECTIONS
+{
+  /* Read-only sections, merged into text segment: */
+  .hash          : { *(.hash) }
+  .dynsym        : { *(.dynsym) }
+  .dynstr        : { *(.dynstr) }
+  .gnu.version   : { *(.gnu.version) }
+  .gnu.version_d : { *(.gnu.version_d) }
+  .gnu.version_r : { *(.gnu.version_r) }
+  .rel.init      : { *(.rel.init) }
+  .rela.init     : { *(.rela.init) }
+  .rel.text      :
+  {
+    *(.rel.text)
+    *(.rel.text.*)
+    *(.rel.gnu.linkonce.t*)
+  }
+  .rela.text     :
+  {
+    *(.rela.text)
+    *(.rela.text.*)
+    *(.rela.gnu.linkonce.t*)
+  }
+  .rel.fini      : { *(.rel.fini) }
+  .rela.fini     : { *(.rela.fini) }
+  .rel.rodata    :
+  {
+    *(.rel.rodata)
+    *(.rel.rodata.*)
+    *(.rel.gnu.linkonce.r*)
+  }
+  .rela.rodata   :
+  {
+    *(.rela.rodata)
+    *(.rela.rodata.*)
+    *(.rela.gnu.linkonce.r*)
+  }
+  .rel.data      :
+  {
+    *(.rel.data)
+    *(.rel.data.*)
+    *(.rel.gnu.linkonce.d*)
+  }
+  .rela.data     :
+  {
+    *(.rela.data)
+    *(.rela.data.*)
+    *(.rela.gnu.linkonce.d*)
+  }
+  .rel.ctors     : { *(.rel.ctors) }
+  .rela.ctors    : { *(.rela.ctors) }
+  .rel.dtors     : { *(.rel.dtors) }
+  .rela.dtors    : { *(.rela.dtors) }
+  .rel.got       : { *(.rel.got) }
+  .rela.got      : { *(.rela.got) }
+  .rel.bss       : { *(.rel.bss) }
+  .rela.bss      : { *(.rela.bss) }
+  .rel.plt       : { *(.rel.plt) }
+  .rela.plt      : { *(.rela.plt) }
+
+  /* Internal text space or external memory.  */
+  .text :
+  {
+    *(.vectors)
+    KEEP(*(.vectors))
+    /* For data that needs to reside in the lower 64k of progmem.  */
+    *(.progmem.gcc*)
+    /* PR 13812: Placing the trampolines here gives a better chance
+       that they will be in range of the code that uses them.  */
+    . = ALIGN(2);
+    __trampolines_start = . ;
+    /* The jump trampolines for the 16-bit limited relocs will reside here.  */
+    *(.trampolines)
+    *(.trampolines*)
+    __trampolines_end = . ;
+    *(.progmem*)
+    . = ALIGN(2);
+    /* For future tablejump instruction arrays for 3 byte pc devices.
+       We don't relax jump/call instructions within these sections.  */
+    *(.jumptables)
+    *(.jumptables*)
+    /* For code that needs to reside in the lower 128k progmem.  */
+    *(.lowtext)
+    *(.lowtext*)
+    __ctors_start = . ;
+    *(.ctors)
+    __ctors_end = . ;
+    __dtors_start = . ;
+    *(.dtors)
+    __dtors_end = . ;
+    KEEP(SORT(*)(.ctors))
+    KEEP(SORT(*)(.dtors))
+    /* From this point on, we don't bother about wether the insns are
+       below or above the 16 bits boundary.  */
+    *(.init0)  /* Start here after reset.  */
+    KEEP (*(.init0))
+    *(.init1)
+    KEEP (*(.init1))
+    *(.init2)  /* Clear __zero_reg__, set up stack pointer.  */
+    KEEP (*(.init2))
+    *(.init3)
+    KEEP (*(.init3))
+    *(.init4)  /* Initialize data and BSS.  */
+    KEEP (*(.init4))
+    *(.init5)
+    KEEP (*(.init5))
+    *(.init6)  /* C++ constructors.  */
+    KEEP (*(.init6))
+    *(.init7)
+    KEEP (*(.init7))
+    *(.init8)
+    KEEP (*(.init8))
+    *(.init9)  /* Call main().  */
+    KEEP (*(.init9))
+    *(.text)
+    . = ALIGN(2);
+    *(.text.*)
+    . = ALIGN(2);
+    *(.fini9)  /* _exit() starts here.  */
+    KEEP (*(.fini9))
+    *(.fini8)
+    KEEP (*(.fini8))
+    *(.fini7)
+    KEEP (*(.fini7))
+    *(.fini6)  /* C++ destructors.  */
+    KEEP (*(.fini6))
+    *(.fini5)
+    KEEP (*(.fini5))
+    *(.fini4)
+    KEEP (*(.fini4))
+    *(.fini3)
+    KEEP (*(.fini3))
+    *(.fini2)
+    KEEP (*(.fini2))
+    *(.fini1)
+    KEEP (*(.fini1))
+    *(.fini0)  /* Infinite loop after program termination.  */
+    KEEP (*(.fini0))
+    _etext = . ;
+  } > TEXT
+  
+  /* Since there is a few ram space, we place rodata exclusively in flash */
+  .rodata :
+  {
+    *(.rodata)  /* .rodata sections (constants, strings, etc.) */
+    *(.rodata*) /* .rodata* sections (constants, strings, etc.) */
+      
+  } > TEXT
+  
+  .data :
+  {
+    PROVIDE (__data_start = .) ;
+    *(.data)
+    *(.data*)
+    *(.gnu.linkonce.d*)
+    . = ALIGN(2);
+    _edata = . ;
+    PROVIDE (__data_end = .) ;
+  } > DATA AT> TEXT
+
+  .bss  ADDR(.data) + SIZEOF (.data)   : AT (ADDR (.bss))
+  {
+    PROVIDE (__bss_start = .) ;
+    *(.bss)
+    *(.bss*)
+    *(COMMON)
+    PROVIDE (__bss_end = .) ;
+  } > DATA
+
+  __data_load_start = LOADADDR(.data);
+  __data_load_end = __data_load_start + SIZEOF(.data);
+  /* Global data not cleared after reset.  */
+  .noinit :
+  {
+    PROVIDE (__noinit_start = .) ;
+    *(.noinit*)
+    PROVIDE (__noinit_end = .) ;
+    _end = . ;
+    PROVIDE (__heap_start = .) ;
+  } > DATA
+
+  .eeprom :
+  {
+    /* See .data above...  */
+    KEEP(*(.eeprom*))
+    __eeprom_end = . ;
+  } > EEPROM
+  
+  .fuse :
+  {
+    KEEP(*(.fuse))
+    KEEP(*(.lfuse))
+    KEEP(*(.hfuse))
+    KEEP(*(.efuse))
+  } > FUSE
+
+  .lock :
+  {
+    KEEP(*(.lock*))
+  } > LOCK
+  
+  .signature  :
+  {
+    KEEP(*(.signature*))
+  } > SIGNATURE
+
+  .user_signatures  :
+  {
+    KEEP(*(.user_signatures*))
+  } > USER_SIGNATURES
+  
+  /* Stabs debugging sections.  */
+  .stab             0 : { *(.stab) }
+  .stabstr          0 : { *(.stabstr) }
+  .stab.excl        0 : { *(.stab.excl) }
+  .stab.exclstr     0 : { *(.stab.exclstr) }
+  .stab.index       0 : { *(.stab.index) }
+  .stab.indexstr    0 : { *(.stab.indexstr) }
+  .comment          0 : { *(.comment) }
+  .note.gnu.build-id  : { *(.note.gnu.build-id) }
+  /* DWARF debug sections.
+     Symbols in the DWARF debugging sections are relative to the beginning
+     of the section so we begin them at 0.  */
+  /* DWARF 1 */
+  .debug            0 : { *(.debug) }
+  .line             0 : { *(.line) }
+  /* GNU DWARF 1 extensions */
+  .debug_srcinfo    0 : { *(.debug_srcinfo) }
+  .debug_sfnames    0 : { *(.debug_sfnames) }
+  /* DWARF 1.1 and DWARF 2 */
+  .debug_aranges    0 : { *(.debug_aranges) }
+  .debug_pubnames   0 : { *(.debug_pubnames) }
+  /* DWARF 2 */
+  .debug_info       0 : { *(.debug_info .gnu.linkonce.wi.*) }
+  .debug_abbrev     0 : { *(.debug_abbrev) }
+  .debug_line       0 : { *(.debug_line .debug_line.* .debug_line_end ) }
+  .debug_frame      0 : { *(.debug_frame) }
+  .debug_str        0 : { *(.debug_str) }
+  .debug_loc        0 : { *(.debug_loc) }
+  .debug_macinfo    0 : { *(.debug_macinfo) }
+  /* SGI/MIPS DWARF 2 extensions */
+  .debug_weaknames  0 : { *(.debug_weaknames) }
+  .debug_funcnames  0 : { *(.debug_funcnames) }
+  .debug_typenames  0 : { *(.debug_typenames) }
+  .debug_varnames   0 : { *(.debug_varnames) }
+  /* DWARF 3 */
+  .debug_pubtypes   0 : { *(.debug_pubtypes) }
+  .debug_ranges     0 : { *(.debug_ranges) }
+  /* DWARF Extension.  */
+  .debug_macro      0 : { *(.debug_macro) }
+}

--- a/Eclipse/m32_uart_buffer/cmds.cpp
+++ b/Eclipse/m32_uart_buffer/cmds.cpp
@@ -33,6 +33,7 @@ void cmd_help(void){
 	uart_transmitnl("Type [cmd] ? to get specific command help.\r\nType \"info\" for a command list");
 	uart_prompt();
 }
+
 void cmd_param(void){
 	uart_transmitnl("Params :");
 	uart_transmitByte(48+nbParams);

--- a/Eclipse/m32_uart_buffer/cmds.h
+++ b/Eclipse/m32_uart_buffer/cmds.h
@@ -28,7 +28,7 @@ static const cmd_t cmd_table[] = {
 		{ cmd_help, "help","Displays available help, use help [cmd] to get specific command help" },
 		{ cmd_clear, "clear","Clears the screen" },
 		{ cmd_param, "param","Displays command parameters in a list" },
-		{cmd_reboot, "reboot","Reboot the target, immediate, no arguments" }
+		{ cmd_reboot, "reboot","Reboot the target, immediate, no arguments" }
 };
 
 #define NB_COMMANDS (sizeof(cmd_table) / sizeof(cmd_table[0]))

--- a/Eclipse/m32_uart_buffer/cmds.h
+++ b/Eclipse/m32_uart_buffer/cmds.h
@@ -30,7 +30,7 @@ static const cmd_t cmd_table[] = {
 		{ cmd_param, "param","Displays command parameters in a list" },
 		{cmd_reboot, "reboot","Reboot the target, immediate, no arguments" }
 };
-static const uint8_t NB_COMMANDS = sizeof (cmd_table)/ sizeof (cmd_t);
 
+#define NB_COMMANDS (sizeof(cmd_table) / sizeof(cmd_table[0]))
 
 #endif /* CMDS_H_ */

--- a/Eclipse/m32_uart_buffer/uart_interpreter.cpp
+++ b/Eclipse/m32_uart_buffer/uart_interpreter.cpp
@@ -96,6 +96,7 @@ void uart_transmitnl(const char* data) {
 void uart_prompt(void) {
 	uart_transmit("\r\n>");
 }
+
 void uart_isr_udre(void) {
 	if (uart_tx_head != uart_tx_tail) {
 		uart_tx_tail = ( uart_tx_tail + 1 ) & UART_BUFFER_MASK;

--- a/Eclipse/m32_uart_buffer/uart_interpreter.cpp
+++ b/Eclipse/m32_uart_buffer/uart_interpreter.cpp
@@ -1,8 +1,35 @@
 #include "uart_interpreter.h"
 
+// Global variable definitions
 unsigned char* params[MAXPARAM];
 uint8_t nbParams;
 
+// Static variable definitions
+static volatile uint8_t  uart_buff_rx[UART_BUFFER_SIZE];
+static volatile uint8_t  uart_rx_head;
+static volatile uint8_t  uart_rx_tail;
+
+static volatile uint8_t  uart_buff_tx[UART_BUFFER_SIZE];
+static volatile uint8_t  uart_tx_head;
+static volatile uint8_t  uart_tx_tail;
+
+static unsigned char cmd_buffer[UART_BUFFER_SIZE];
+static unsigned char last_cmd[UART_BUFFER_SIZE];
+
+// Static function declarations
+static uint8_t uart_receivedAvailable(void);
+static uint8_t uart_transmitAvailable(void);
+static void uart_buff_rx_removeLast(void);
+static void uart_rx_emptyBuffer(void);
+static void uart_rx_loadBuffer(const unsigned char* s);
+static void uart_rx_printBuffer(void);
+static void uart_rx_printEmptyBuffer(void);
+
+static uint8_t cmd_cmp(const char* s1,const char* s2);
+static void cmd_process(void);
+static void cmd_parse(void);
+ 
+// Function definitions
 void uart_init(void){
 	UBRRH = (BAUDRATE>>8);
 	UBRRL = BAUDRATE;
@@ -119,20 +146,20 @@ void uart_isr_rxc(void) {
 	sei();
 }
 
-uint8_t uart_receivedAvailable(void) {
+static uint8_t uart_receivedAvailable(void) {
 	if(uart_rx_head>=uart_rx_tail)	return uart_rx_head-uart_rx_tail;
 	return uart_rx_head + UART_BUFFER_SIZE - uart_rx_tail;
 }
 
-uint8_t uart_transmitAvailable(void) {
+static uint8_t uart_transmitAvailable(void) {
 	if(uart_tx_head>=uart_rx_tail)	return uart_tx_head-uart_tx_tail;
 	return uart_tx_head + UART_BUFFER_SIZE - uart_tx_tail;
 }
 
-void uart_rx_printEmptyBuffer(void) {
+static void uart_rx_printEmptyBuffer(void) {
 	while(uart_receivedAvailable()>0)uart_transmitByte(uart_receiveByte());
 }
-void uart_rx_printBuffer(void) {
+static void uart_rx_printBuffer(void) {
 	uart_transmit("");
 	uint8_t i=uart_rx_tail;
 	while(i!=uart_rx_head){
@@ -140,27 +167,27 @@ void uart_rx_printBuffer(void) {
 		i = (i+1) & UART_BUFFER_MASK;
 	}
 }
-void uart_rx_emptyBuffer(void) {
+static void uart_rx_emptyBuffer(void) {
 	while(uart_receivedAvailable()>0)uart_receiveByte();
 }
-void uart_rx_loadBuffer(const unsigned char* s) {
+static void uart_rx_loadBuffer(const unsigned char* s) {
 	for(uint8_t i=0, uart_rx_head=uart_rx_tail;s[i]!=NULLCHAR;i++){
 		uart_buff_rx[uart_rx_head]=s[i];
 		uart_rx_head= (uart_rx_head+1) & UART_BUFFER_MASK;
 	}
 }
 
-void uart_buff_rx_removeLast(void){
+static void uart_buff_rx_removeLast(void){
 	if(uart_rx_head!=uart_rx_tail){
 		if(uart_rx_head==0){
 			uart_rx_head=UART_BUFFER_MASK;
 		}else{
-			uart_rx_head=uart_rx_head-1;
+			uart_rx_head--;
 		}
 	}
 }
 
-uint8_t cmd_cmp(const char* cmd, const char* entry) {
+static uint8_t cmd_cmp(const char* cmd, const char* entry) {
 	uint8_t c=0;
 	while(cmd[c]!=NULLCHAR && entry[c]!=NULLCHAR){
 		if(cmd[c]!=entry[c])return 0;
@@ -171,7 +198,7 @@ uint8_t cmd_cmp(const char* cmd, const char* entry) {
 }
 
 
-void cmd_process(void) {
+static void cmd_process(void) {
 	uint8_t i=0;
 	if(uart_receivedAvailable()<=1){
 		uart_rx_emptyBuffer();
@@ -200,7 +227,7 @@ void cmd_process(void) {
 	uart_prompt();
 }
 
-void cmd_parse(void) {//TODO check
+static void cmd_parse(void) {//TODO check
 	int l;
 	nbParams = 0;
 	for (l=0;l<MAXPARAM;l++)params[l] = NULL;

--- a/Eclipse/m32_uart_buffer/uart_interpreter.cpp
+++ b/Eclipse/m32_uart_buffer/uart_interpreter.cpp
@@ -213,7 +213,7 @@ static void cmd_process(void) {
 	cmd_parse();
 	for (uint8_t cmd = 0; cmd < NB_COMMANDS; cmd++) {
 
-		if (cmd_cmp(cmd_table[cmd].str, (char *)cmd_buffer)) {
+		if (!strcmp(cmd_table[cmd].str, (char *)cmd_buffer)) {
 			if(nbParams>0 && *params[0]=='?'){
 				uart_transmitnl(cmd_table[cmd].descr);
 				uart_prompt();

--- a/Eclipse/m32_uart_buffer/uart_interpreter.h
+++ b/Eclipse/m32_uart_buffer/uart_interpreter.h
@@ -22,7 +22,7 @@
 #define PREV '&'
 #define BACKSPACE 127
 
-#define UART_BUFFER_SIZE 256     // 2 to 256 bytes
+#define UART_BUFFER_SIZE 64     // 2 to 256 bytes
 #define UART_BUFFER_MASK (UART_BUFFER_SIZE - 1)
 #define UARTTXEN()	UCSRB |= (1<<UDRIE)
 #define	UARTTXDIS() UCSRB &= ~(1<<UDRIE)

--- a/Eclipse/m32_uart_buffer/uart_interpreter.h
+++ b/Eclipse/m32_uart_buffer/uart_interpreter.h
@@ -11,6 +11,8 @@
 #define BAUD 38400
 #define BAUDRATE ((F_CPU)/(BAUD*16UL)-1)
 
+#define MAXPARAM 5
+
 #ifndef NULLCHAR
 #define NULLCHAR '\0'
 #endif
@@ -24,43 +26,24 @@
 #define UARTTXEN()	UCSRB |= (1<<UDRIE)
 #define	UARTTXDIS() UCSRB &= ~(1<<UDRIE)
 
-static  uint8_t  uart_buff_rx[UART_BUFFER_SIZE];
-static volatile uint8_t  uart_rx_head;
-static volatile uint8_t  uart_rx_tail;
-static uint8_t  uart_buff_tx[UART_BUFFER_SIZE];
-static volatile uint8_t  uart_tx_head;
-static volatile uint8_t  uart_tx_tail;
+extern unsigned char* params[MAXPARAM];
+extern uint8_t nbParams;
 
 // uart buffering and hardware functions
 void uart_init(void);
-uint8_t  uart_receiveByte(void);
-void uart_transmitByte(uint8_t  data);
-void uart_transmit(const char  *data);
+uint8_t uart_receiveByte(void);
+void uart_transmitByte(uint8_t data);
+void uart_transmit(const char *data);
 void uart_transmitNb(uint8_t data, uint8_t mode);
-void uart_transmitln(const char  *data);
-void uart_transmitnl(const char  *data);
-uint8_t uart_receivedAvailable(void);
-uint8_t uart_transmitAvailable(void);
-void uart_buff_rx_removeLast(void);
-void uart_rx_emptyBuffer(void);
-void uart_rx_loadBuffer(const unsigned char* s);
-void uart_rx_printBuffer(void);
-void uart_rx_printEmptyBuffer(void);
+void uart_transmitln(const char *data);
+void uart_transmitnl(const char *data);
 void uart_prompt(void);
+
+// uart isr
 void uart_isr_udre(void);
 void uart_isr_rxc(void);
 
-//uart command interpreter handling
-
-#define MAXPARAM 5
-extern unsigned char* params[MAXPARAM];
-extern uint8_t nbParams;
-static unsigned char cmd_buffer[UART_BUFFER_SIZE];
-static unsigned char last_cmd[UART_BUFFER_SIZE];
-
-uint8_t cmd_cmp(const char* s1,const char* s2);
-void cmd_process(void);
-void cmd_parse(void);
+// uart command interpreter handling
 uint8_t param_int(uint8_t nb);
 
 #endif

--- a/Eclipse/m32_uart_buffer/uart_interpreter.h
+++ b/Eclipse/m32_uart_buffer/uart_interpreter.h
@@ -1,5 +1,6 @@
-#ifndef UART_INTERPRET_H
-#define UART_INTERPRET_H
+#ifndef UART_INTERPRETER_H_
+#define UART_INTERPRETER_H_
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <avr/io.h>
@@ -46,5 +47,5 @@ void uart_isr_rxc(void);
 // uart command interpreter handling
 uint8_t param_int(uint8_t nb);
 
-#endif
+#endif /* UART_INTERPRETER_H_  */
 


### PR DESCRIPTION
* rodata (read-only data, eg. string litterals, constants...) have been moved to text region (in flash), see the .rodata section in linker script.
* Reduce UART_BUFFER_SIZE from 256 to 64, which decrease the bss size by ten.